### PR TITLE
fix(node): augmenter heap limit memory nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "nest build cli && nest build api",
     "build:api": "nest build api",
     "build:cli": "nest build cli",
-    "cli": "node build/apps/cli/apps/cli/src/main.js",
+    "cli": "node --max-old-space-size=512 build/apps/cli/apps/cli/src/main.js",
     "coverage": "nyc mocha",
     "dev:api": "nest build api && nest start api",
     "dev:cli": "nest build cli && node -r dotenv/config build/apps/cli/apps/cli/src/main.js",


### PR DESCRIPTION
Augmentation de la heap limit memory pour Node car des crashs surviennent lorsqu'elle est trop faible

Nous avons aujourd'hui 39 listeners sur l'événement 'beforeExit', lié aux streams ouverts par les loggers vers Sentry, ce qui pousse NodeJS à créer un warning par défaut en console